### PR TITLE
Heap strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ In order of priority
   seems wrong. In particular, strings are currently C++ std::string objects with
   storage in the C++ heap, evaluation environments are kept outside the heap
   altogether (this interplays with the earlier point about closures)
+  => DONE for strings.
 * numbers other than integers: currently only 64-bit integers are supported.
   Having arbitrary-sized integers, fractions, floats, and complex numbers of
   various kinds seems desirable but not critical. I might do it out of interest

--- a/include/object/list.hpp
+++ b/include/object/list.hpp
@@ -24,7 +24,6 @@ public:
   static List *make(Object *car, Object *cdr);
   static List *of(size_t n, Object **objects);
   static List *of(std::vector<Object *> objects);
-  static std::vector<Object *> flatten(List *list);
   static size_t length(List *list);
 
 private:

--- a/include/object/string.hpp
+++ b/include/object/string.hpp
@@ -6,9 +6,10 @@
 
 namespace lithp {
 class String : public Object {
-  LITHP_HEAP_OBJECT(String);
-
 public:
+  String(const String &other) = delete;
+  virtual bool heap_allocated() override;
+  virtual size_t size() override;
   static String *make(std::string value);
   virtual Type type(void) override;
   virtual void repr(std::ostream &out) override;
@@ -20,8 +21,9 @@ public:
   static String *cast(Object *obj);
 
 private:
-  String(std::string value);
-  std::string value;
+  String() = default;
+  size_t ssize = 0;
+  char *svalue = nullptr;
 };
 } // namespace lithp
 

--- a/include/runtime/heap.hpp
+++ b/include/runtime/heap.hpp
@@ -17,7 +17,7 @@ namespace lithp::allocator {
 // TODO: Should accept config about heap properties.
 void init();
 void shutdown();
-void *get(size_t size);
+char *get(size_t size);
 } // namespace lithp::allocator
 
 #endif // _LITHP_RUNTIME_HEAP_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,12 @@
 
 const std::string prompt = "> ";
 
+int end_program(int exit_code) {
+  lithp::reader::exit();
+  lithp::runtime::shutdown();
+  return exit_code;
+}
+
 int run_repl(void) {
   lithp::runtime::init();
   lithp::reader::init(std::cin);
@@ -21,7 +27,7 @@ int run_repl(void) {
     }
   }
 
-  return EXIT_SUCCESS;
+  return end_program(EXIT_SUCCESS);
 }
 
 void detect_and_remove_shebang(std::istream &infile) {
@@ -54,10 +60,11 @@ int run_file(std::string filename) {
       lithp::Object *expr = lithp::reader::next_expr();
       eval(expr, lithp::runtime::global_env());
     }
+
+    return end_program(EXIT_SUCCESS);
   } catch (const std::exception &e) {
-    return EXIT_FAILURE;
+    return end_program(EXIT_FAILURE);
   }
-  return EXIT_SUCCESS;
 }
 
 int main(int argc, char *argv[]) {

--- a/src/object/string.cpp
+++ b/src/object/string.cpp
@@ -19,8 +19,8 @@ String *String::make(std::string value) {
 
 bool String::heap_allocated() { return true; }
 size_t String::size() {
-  // FIXME: This will break alignment or cause other issues.
-  return sizeof(String) + ssize;
+  // TODO: Ugly fix to repair alignment, improve.
+  return sizeof(String) + ((ssize / 8) + 1) * 8;
 }
 Type String::type() { return Type::String; }
 void String::repr(std::ostream &out) { out << '"' << svalue << '"'; }

--- a/src/object/string.cpp
+++ b/src/object/string.cpp
@@ -4,7 +4,7 @@ namespace lithp {
 String *String::make(std::string value) {
   size_t ssize = value.length() + 1;
   size_t alloc_size = sizeof(String) + ssize;
-  char *ptr = (char *)allocator::get(alloc_size);
+  char *ptr = allocator::get(alloc_size);
   String *str = new (ptr) String;
   ptr += sizeof(String);
   char *svalue = ptr;

--- a/src/object/string.cpp
+++ b/src/object/string.cpp
@@ -1,15 +1,44 @@
 #include <lithp.hpp>
 
 namespace lithp {
-String *String::make(std::string value) { return HEAP_NEW(String){value}; }
+String *String::make(std::string value) {
+  size_t ssize = value.length() + 1;
+  size_t alloc_size = sizeof(String) + ssize;
+  char *ptr = (char *)allocator::get(alloc_size);
+  String *str = new (ptr) String;
+  ptr += sizeof(String);
+  char *svalue = ptr;
+  for (char c : value) {
+    *ptr++ = c;
+  }
+  *ptr = '\0';
+  str->ssize = ssize;
+  str->svalue = svalue;
+  return str;
+}
+
+bool String::heap_allocated() { return true; }
+size_t String::size() {
+  // FIXME: This will break alignment or cause other issues.
+  return sizeof(String) + ssize;
+}
 Type String::type() { return Type::String; }
-void String::repr(std::ostream &out) { out << '"' << value << '"'; }
+void String::repr(std::ostream &out) { out << '"' << svalue << '"'; }
 RefStream String::refs() { return RefStream::empty(); }
-Object *String::copy_to(void *mem) { return new (mem) String{value}; }
-std::string String::display() { return value; }
+Object *String::copy_to(void *mem) {
+  String *other = new (mem) String;
+  other->ssize = ssize;
+  char *valptr = (char *)mem;
+  valptr += sizeof(String);
+  for (size_t i = 0; i < ssize; i++) {
+    valptr[i] = svalue[i];
+  }
+  other->svalue = valptr;
+  return other;
+}
+std::string String::display() { return std::string{svalue}; }
 
 bool String::is_instance(Object *obj) { LITHP_CHECK_TYPE(obj, String); }
 String *String::cast(Object *obj) { LITHP_CAST_TO_TYPE(obj, String); }
 
-String::String(std::string value) : value{std::move(value)} {}
 } // namespace lithp

--- a/src/runtime/heap.cpp
+++ b/src/runtime/heap.cpp
@@ -9,14 +9,14 @@ public:
   Allocator(size_t mem_size = 0x100000); // 1MB default
   Allocator(const Allocator &alloc) = delete;
   ~Allocator();
-  void *allocate(size_t size);
+  char *allocate(size_t size);
 
 private:
   char *heaps[2];
   size_t heap_pos = 0;
   size_t heap_idx = 0;
   size_t mem_size;
-  void *heap_ptr();
+  char *heap_ptr();
   void ensure_space(size_t amount);
   void do_gc();
   void relocate(Object **obj, char *target, size_t *pos);
@@ -41,14 +41,14 @@ Allocator::~Allocator() {
   }
 }
 
-void *Allocator::allocate(size_t size) {
+char *Allocator::allocate(size_t size) {
   ensure_space(size);
-  void *allocated = heap_ptr();
+  char *allocated = heap_ptr();
   heap_pos += size;
   return allocated;
 }
 
-void *Allocator::heap_ptr() { return &heaps[heap_idx][heap_pos]; }
+char *Allocator::heap_ptr() { return &heaps[heap_idx][heap_pos]; }
 
 void Allocator::ensure_space(size_t amount) {
   // For very large allocations (e.g. huge strings) we may need to double more
@@ -74,6 +74,7 @@ void Allocator::do_gc() {
   size_t size;
   while (pos < heap_pos) {
     Object *obj = (Object *)&heaps[heap_idx][pos];
+    // TODO: Ensure alignment is correct after this step
     size = obj->size();
     delete obj;
     pos += size;
@@ -131,7 +132,8 @@ void Allocator::double_heap_size() {
 
 static Allocator *alloc = nullptr;
 
-void *get(size_t size) {
+char *get(size_t size) {
+  // TODO: Should always return an aligned pointer
   if (alloc) {
     return alloc->allocate(size);
   }

--- a/src/runtime/heap.cpp
+++ b/src/runtime/heap.cpp
@@ -51,7 +51,9 @@ void *Allocator::allocate(size_t size) {
 void *Allocator::heap_ptr() { return &heaps[heap_idx][heap_pos]; }
 
 void Allocator::ensure_space(size_t amount) {
-  if (heap_pos + amount >= mem_size) {
+  // For very large allocations (e.g. huge strings) we may need to double more
+  // than once.
+  while (heap_pos + amount >= mem_size) {
     do_gc();
     if (heap_pos > 0.8 * mem_size) { // heap more than 80% full
       double_heap_size();


### PR DESCRIPTION
Strings are now stored on the lithp heap and no longer in the C++ heap.
At the same time, alignment of heap objects was made explicit since the compiler will no longer do this for us.