### PR TITLE
Env overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,9 @@ my leisure.
 # What's missing?
 In order of priority
 * garbage collection: partially implemented but untested
-* closures: although somewhat supported, closing over variables works but
-  keeping them alive is not yet possible
 * file I/O: not implemented yet, probably not hard
 * standard library: currently everything is built-in, but most of the standard
   library should eventually be written in Lithp
-* complete heap: some object types will store data outside the managed heap.
-  This does not mean that the memory is forgotten by the garbage collector, but
-  seems wrong. In particular, evaluation environments are kept outside the heap
-  altogether (this interplays with the earlier point about closures)
-  => DONE for strings.
 * numbers other than integers: currently only 64-bit integers are supported.
   Having arbitrary-sized integers, fractions, floats, and complex numbers of
   various kinds seems desirable but not critical. I might do it out of interest
@@ -77,8 +70,8 @@ In order of priority
 # Why did I do it?
 I needed a non-trivial project I could reasonably put together in C or C++ since
 I consider myself fairly proficient in these languages (not expert-level) but
-without experience with regards to project organization and refactoring and such
-things that are only learned through projects.
+without experience from larger projects as some skills can only be gained that
+way.
 
 Writing a Lisp had been on my list for a while and I had a few half-hearted and
 therefore failed attempts. Recovering from a surgery I decided to try again.

--- a/include/lithp/lib/stdlib.hpp
+++ b/include/lithp/lib/stdlib.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_stdlib(Environment &env);
+void load_stdlib(Environment *env);
 }
 
 #endif // _LITHP_LIB_H_

--- a/include/lithp/lithp.hpp
+++ b/include/lithp/lithp.hpp
@@ -37,9 +37,9 @@ bool is_true(Object *obj);
 bool is_false(Object *obj);
 bool is_definition(Object *obj);
 
-Object *eval(Object *obj, Environment &env);
-Object *eval_sequence(size_t n, Object **seq, Environment &env);
-Object *apply(Function *fun, List *args, Environment &env);
+Object *eval(Object *obj, Environment *env);
+Object *eval_sequence(size_t n, Object **seq, Environment *env);
+Object *apply(Function *fun, List *args, Environment *env);
 
 std::string to_string(Object *obj);
 std::string display(Object *obj);

--- a/include/lithp/object/lambda.hpp
+++ b/include/lithp/object/lambda.hpp
@@ -12,7 +12,7 @@ class Lambda : public Function {
     LITHP_HEAP_OBJECT(Lambda);
 
   public:
-    static Lambda *of(size_t nargs, Object **args, Environment &env);
+    static Lambda *of(size_t nargs, Object **args, Environment *env);
     virtual ~Lambda() override;
     virtual void repr(std::ostream &out) override;
     virtual RefStream refs() override;
@@ -25,14 +25,14 @@ class Lambda : public Function {
 
   private:
     Lambda(size_t nargs, Symbol **syms, bool rest, Symbol *rest_sym,
-           size_t progc, Object **progv, Environment &parent);
+           size_t progc, Object **progv, Environment *parent);
     size_t nslots;
     Symbol **slot_syms;
     bool has_rest;
     Symbol *rest_sym;
     size_t progc;
     Object **progv;
-    Environment &parent;
+    Environment *parent;
 };
 
 } // namespace lithp

--- a/include/lithp/object/special_form.hpp
+++ b/include/lithp/object/special_form.hpp
@@ -6,7 +6,7 @@
 #include <lithp/object/symbol.hpp>
 
 namespace lithp {
-typedef Object *(*snative)(size_t, Object **, Environment &);
+typedef Object *(*snative)(size_t, Object **, Environment *);
 
 class SpecialForm : public Object {
     LITHP_NO_PRINT(SpecialForm);
@@ -17,10 +17,10 @@ class SpecialForm : public Object {
     virtual Type type(void) override;
     virtual RefStream refs(void) override;
     static bool exists(Symbol *sym);
-    static void init();
+    static void init(void);
     static SpecialForm *cast(Object *obj);
     static bool is_instance(Object *obj);
-    Object *eval(size_t nargs, Object **args, Environment &env);
+    Object *evaluate(size_t nargs, Object **args, Environment *env);
 
   private:
     SpecialForm() = delete;

--- a/include/lithp/object/symbol.hpp
+++ b/include/lithp/object/symbol.hpp
@@ -30,6 +30,7 @@ class Symbol : public Object {
     Object *get_global_value();
     void set_global_value(Object *obj);
     static void clear_global_associations();
+    static RefStream global_references();
 
   private:
     Symbol() = delete;

--- a/include/lithp/object/symbol.hpp
+++ b/include/lithp/object/symbol.hpp
@@ -26,12 +26,18 @@ class Symbol : public Object {
     static bool is_valid(std::string_view name);
     bool self_evaluating();
     std::string get_name();
+    bool has_global_value();
+    Object *get_global_value();
+    void set_global_value(Object *obj);
+    static void clear_global_associations();
 
   private:
     Symbol() = delete;
     Symbol(const Symbol &other) = delete;
     Symbol(std::string name);
     std::string name;
+    bool associated = false;
+    Object *global_value = nullptr;
 };
 } // namespace lithp
 

--- a/include/lithp/object/types.hpp
+++ b/include/lithp/object/types.hpp
@@ -15,6 +15,7 @@ enum class Type {
     SpecialForm,
     String,
     Symbol,
+    Environment,
 };
 
 std::string type_name(Type t);

--- a/include/lithp/runtime/environment.hpp
+++ b/include/lithp/runtime/environment.hpp
@@ -3,6 +3,7 @@
 
 #include <unordered_map>
 
+#include <lithp/object.hpp>
 #include <lithp/util/refstream.hpp>
 
 namespace lithp {
@@ -10,18 +11,21 @@ namespace lithp {
 class Function;
 namespace runtime {
 
-class Environment {
+class Environment : public Object {
   public:
-    Environment(Environment *parent = nullptr);
-    void set(Symbol *sym, Object *obj);
-    void def(Symbol *sym, Object *obj);
-    Object *get(Symbol *sym);
-    bool knows(Symbol *sym);
-    RefStream refs();
-
-  private:
-    Environment *parent = nullptr;
-    std::unordered_map<Symbol *, Object *> definitions{};
+    virtual bool heap_allocated(void) override = 0;
+    virtual size_t size(void) override = 0;
+    virtual Type type(void) override = 0;
+    virtual void repr(std::ostream &out) override = 0;
+    virtual RefStream refs(void) override = 0;
+    virtual Object *copy_to(void *mem) override = 0;
+    virtual void set(Symbol *sym, Object *obj) = 0;
+    virtual void def(Symbol *sym, Object *obj) = 0;
+    virtual Object *get(Symbol *sym) = 0;
+    virtual bool knows(Symbol *sym) = 0;
+    static Environment *get_global();
+    static Environment *make_local(Environment *parent);
+    virtual ~Environment() = default;
 };
 } // namespace runtime
 } // namespace lithp

--- a/include/lithp/runtime/runtime.hpp
+++ b/include/lithp/runtime/runtime.hpp
@@ -10,7 +10,7 @@ class SpecialForm;
 namespace runtime {
 void init();
 RefStream live_objects();
-Environment &global_env();
+Environment *global_env();
 void register_builtin(Builtin *b);
 void register_special_form(SpecialForm *s);
 void shutdown();

--- a/include/lithp/runtime/stack.hpp
+++ b/include/lithp/runtime/stack.hpp
@@ -40,7 +40,7 @@ void call_in_current_frame(Function *fun);
  * Evaluate the special form `spec` in the current frame with the previously
  * emplaced arguments. Can make use of and manipulate `env`.
  */
-void eval_in_current_frame(SpecialForm *spec, Environment &env);
+void eval_in_current_frame(SpecialForm *spec, Environment *env);
 /**
  * Drop the current frame and return
  */

--- a/src/lib/lib_data.cpp
+++ b/src/lib/lib_data.cpp
@@ -72,17 +72,17 @@ Object *setcdr(size_t, Object **args) {
 }
 } // namespace data
 
-void load_data(Environment &env) {
-    env.def(SYM("eq?"), FUN(2, false, data::eq));
-    env.def(SYM("null?"), FUN(1, false, data::null));
-    env.def(SYM("car"), FUN(1, false, data::car));
-    env.def(SYM("cdr"), FUN(1, false, data::cdr));
-    env.def(SYM("nth"), FUN(2, false, data::nth));
+void load_data(Environment *env) {
+    env->def(SYM("eq?"), FUN(2, false, data::eq));
+    env->def(SYM("null?"), FUN(1, false, data::null));
+    env->def(SYM("car"), FUN(1, false, data::car));
+    env->def(SYM("cdr"), FUN(1, false, data::cdr));
+    env->def(SYM("nth"), FUN(2, false, data::nth));
 
-    env.def(SYM("cons"), FUN(2, false, data::cons));
-    env.def(SYM("list"), FUN(0, true, data::list));
-    env.def(SYM("pair?"), FUN(1, false, data::listp));
-    env.def(SYM("set-car!"), FUN(2, false, data::setcar));
-    env.def(SYM("set-cdr!"), FUN(2, false, data::setcdr));
+    env->def(SYM("cons"), FUN(2, false, data::cons));
+    env->def(SYM("list"), FUN(0, true, data::list));
+    env->def(SYM("pair?"), FUN(1, false, data::listp));
+    env->def(SYM("set-car!"), FUN(2, false, data::setcar));
+    env->def(SYM("set-cdr!"), FUN(2, false, data::setcdr));
 }
 } // namespace lithp::lib

--- a/src/lib/lib_data.hpp
+++ b/src/lib/lib_data.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_data(Environment &env);
+void load_data(Environment *env);
 } // namespace lithp::lib
 
 #endif // _LITHP_LIB_DATA_H_

--- a/src/lib/lib_internal.cpp
+++ b/src/lib/lib_internal.cpp
@@ -18,7 +18,7 @@ Object *type_of(size_t, Object **args) {
 }
 } // namespace internal
 
-void load_internal(Environment &env) {
-    env.def(SYM("type-of"), FUN(1, false, internal::type_of));
+void load_internal(Environment *env) {
+    env->def(SYM("type-of"), FUN(1, false, internal::type_of));
 }
 } // namespace lithp::lib

--- a/src/lib/lib_internal.hpp
+++ b/src/lib/lib_internal.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_internal(Environment &env);
+void load_internal(Environment *env);
 } // namespace lithp::lib
 
 #endif // _LITHP_LIB_INTERNAL_H_

--- a/src/lib/lib_io.cpp
+++ b/src/lib/lib_io.cpp
@@ -19,8 +19,8 @@ Object *echo(size_t nargs, Object **args) {
 }
 } // namespace io
 
-void load_io(Environment &env) {
-    env.def(SYM("echo"), FUN(0, true, io::echo));
+void load_io(Environment *env) {
+    env->def(SYM("echo"), FUN(0, true, io::echo));
     // TODO
 }
 } // namespace lithp::lib

--- a/src/lib/lib_io.hpp
+++ b/src/lib/lib_io.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_io(Environment &env);
+void load_io(Environment *env);
 } // namespace lithp::lib
 
 #endif // _LITHP_LIB_IO_H_

--- a/src/lib/lib_logic.cpp
+++ b/src/lib/lib_logic.cpp
@@ -21,9 +21,9 @@ Object *false_(size_t, Object **args) {
     return Boolean::of(args[0] == Boolean::False());
 }
 } // namespace logic
-void load_logic(Environment &env) {
-    env.def(SYM("not"), FUN(1, false, logic::not_));
-    env.def(SYM("true?"), FUN(1, false, logic::true_));
-    env.def(SYM("false?"), FUN(1, false, logic::false_));
+void load_logic(Environment *env) {
+    env->def(SYM("not"), FUN(1, false, logic::not_));
+    env->def(SYM("true?"), FUN(1, false, logic::true_));
+    env->def(SYM("false?"), FUN(1, false, logic::false_));
 }
 } // namespace lithp::lib

--- a/src/lib/lib_logic.hpp
+++ b/src/lib/lib_logic.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_logic(Environment &env);
+void load_logic(Environment *env);
 } // namespace lithp::lib
 
 #endif // _LITHP_LIB_LOGIC_H_

--- a/src/lib/lib_numeric.cpp
+++ b/src/lib/lib_numeric.cpp
@@ -45,11 +45,11 @@ static Object *is_number(size_t, Object **args) {
 }
 } // namespace numeric
 
-void load_numeric(Environment &env) {
-    env.def(SYM("+"), FUN(0, true, numeric::add));
-    env.def(SYM("-"), FUN(0, true, numeric::minus));
-    env.def(SYM("*"), FUN(0, true, numeric::mult));
-    env.def(SYM("/"), FUN(2, false, numeric::divide));
-    env.def(SYM("number?"), FUN(1, false, numeric::is_number));
+void load_numeric(Environment *env) {
+    env->def(SYM("+"), FUN(0, true, numeric::add));
+    env->def(SYM("-"), FUN(0, true, numeric::minus));
+    env->def(SYM("*"), FUN(0, true, numeric::mult));
+    env->def(SYM("/"), FUN(2, false, numeric::divide));
+    env->def(SYM("number?"), FUN(1, false, numeric::is_number));
 }
 } // namespace lithp::lib

--- a/src/lib/lib_numeric.hpp
+++ b/src/lib/lib_numeric.hpp
@@ -4,7 +4,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::lib {
-void load_numeric(Environment &env);
+void load_numeric(Environment *env);
 } // namespace lithp::lib
 
 #endif // _LITHP_LIB_NUMERIC_H_

--- a/src/lib/stdlib.cpp
+++ b/src/lib/stdlib.cpp
@@ -8,7 +8,7 @@
 #include "lib_numeric.hpp"
 
 namespace lithp::lib {
-void load_stdlib(Environment &env) {
+void load_stdlib(Environment *env) {
     load_data(env);
     load_io(env);
     load_internal(env);

--- a/src/lithp.cpp
+++ b/src/lithp.cpp
@@ -98,8 +98,8 @@ bool is_definition(Object *obj) {
     return car(as_list) == Symbol::intern("define");
 }
 
-static Object *eval_special_form(List *list, Environment &env) {
-    SpecialForm *form = SpecialForm::cast(env.get(Symbol::cast(car(list))));
+static Object *eval_special_form(List *list, Environment *env) {
+    SpecialForm *form = SpecialForm::cast(env->get(Symbol::cast(car(list))));
     List *args = List::cast(cdr(list));
     runtime::stack::new_frame(list);
     size_t n = 0;
@@ -111,7 +111,7 @@ static Object *eval_special_form(List *list, Environment &env) {
     return runtime::stack::yield_frame();
 }
 
-static Object *eval_list(List *list, Environment &env) {
+static Object *eval_list(List *list, Environment *env) {
     if (list->empty()) {
         return nil();
     }
@@ -120,11 +120,11 @@ static Object *eval_list(List *list, Environment &env) {
     Object *head = car(list);
     switch (type_of(head)) {
     case Type::Symbol:
-        switch (type_of(env.get(Symbol::cast(head)))) {
+        switch (type_of(env->get(Symbol::cast(head)))) {
         case Type::SpecialForm:
             return eval_special_form(list, env);
         case Type::Function:
-            fun = Function::cast(env.get(Symbol::cast(head)));
+            fun = Function::cast(env->get(Symbol::cast(head)));
             break;
         default:
             throw std::runtime_error{"not a function: " + to_string(car(list))};
@@ -143,14 +143,14 @@ static Object *eval_list(List *list, Environment &env) {
     return apply(fun, List::cast(cdr(list)), env);
 }
 
-static Object *eval_symbol(Symbol *sym, Environment &env) {
+static Object *eval_symbol(Symbol *sym, Environment *env) {
     if (sym->self_evaluating()) {
         return sym;
     }
-    return env.get(sym);
+    return env->get(sym);
 }
 
-Object *eval(Object *obj, Environment &env) {
+Object *eval(Object *obj, Environment *env) {
     if (is_null(obj)) {
         return nil();
     }
@@ -168,7 +168,7 @@ Object *eval(Object *obj, Environment &env) {
     }
 }
 
-Object *eval_sequence(size_t n, Object **seq, Environment &env) {
+Object *eval_sequence(size_t n, Object **seq, Environment *env) {
     Object *result = nil();
     for (size_t i = 0; i < n; i++) {
         result = eval(seq[i], env);
@@ -176,7 +176,7 @@ Object *eval_sequence(size_t n, Object **seq, Environment &env) {
     return result;
 }
 
-Object *apply(Function *fun, List *args, Environment &env) {
+Object *apply(Function *fun, List *args, Environment *env) {
     if (is_null(fun)) {
         throw std::runtime_error{"not a function: " + to_string(fun)};
     }

--- a/src/object/builtin.cpp
+++ b/src/object/builtin.cpp
@@ -12,9 +12,7 @@ Builtin::Builtin(size_t nargs, bool rest, fnative fnat)
     : nslots{nargs}, has_rest{rest}, native{fnat} {}
 
 Builtin *Builtin::make(size_t nargs, bool rest, fnative *fnat) {
-    Builtin *b = new Builtin{nargs, rest, fnat};
-    runtime::register_builtin(b);
-    return b;
+    return new Builtin{nargs, rest, fnat};
 }
 
 size_t Builtin::size() {

--- a/src/object/lambda.cpp
+++ b/src/object/lambda.cpp
@@ -1,7 +1,7 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp {
-Lambda *Lambda::of(size_t nargs, Object **args, Environment &env) {
+Lambda *Lambda::of(size_t nargs, Object **args, Environment *env) {
     // (De-)construct argument list
     List *arglist = List::cast(args[0]);
     size_t nslots = 0;
@@ -43,7 +43,7 @@ Lambda *Lambda::of(size_t nargs, Object **args, Environment &env) {
 }
 
 Lambda::Lambda(size_t nargs, Symbol **syms, bool rest, Symbol *rest_sym,
-               size_t progc, Object **progv, Environment &parent)
+               size_t progc, Object **progv, Environment *parent)
     : nslots{nargs}, slot_syms{syms}, has_rest{rest}, rest_sym{rest_sym},
       progc{progc}, progv{progv}, parent{parent} {}
 
@@ -60,7 +60,7 @@ void Lambda::repr(std::ostream &out) {
 
 RefStream Lambda::refs() {
     // TODO: Include program
-    return parent.refs();
+    return parent->refs();
 }
 
 Object *Lambda::copy_to(void *) {
@@ -68,12 +68,12 @@ Object *Lambda::copy_to(void *) {
 }
 
 Object *Lambda::call(size_t nargs, Object **args) {
-    Environment env{&parent};
+    Environment *env = Environment::make_local(parent);
     for (size_t i = 0; i < nslots; i++) {
-        env.def(slot_syms[i], args[i]);
+        env->def(slot_syms[i], args[i]);
     }
     if (has_rest) {
-        env.def(rest_sym, List::of(nargs - nslots, &args[nslots]));
+        env->def(rest_sym, List::of(nargs - nslots, &args[nslots]));
     }
 
     return eval_sequence(progc, progv, env);

--- a/src/object/symbol.cpp
+++ b/src/object/symbol.cpp
@@ -1,3 +1,5 @@
+#include <functional>
+
 #include <lithp/lithp.hpp>
 
 namespace lithp {
@@ -41,7 +43,7 @@ class ChainHead {
 
 #define LITHP_SYMBOL_TABLE_SIZE 1024
 
-typedef void (*symbolAction)(Symbol *);
+typedef std::function<void(Symbol *)> symbolAction;
 
 class SymbolTable {
   public:
@@ -138,6 +140,15 @@ void Symbol::clear_global_associations() {
         sym->associated = false;
         sym->global_value = nil();
     });
+}
+
+RefStream Symbol::global_references() {
+    auto stream = RefStream::empty();
+    symtab.for_each_symbol([&stream](Symbol *sym) mutable -> void {
+        stream.append(RefStream::concat(sym->global_value->refs(),
+                                        RefStream::of(&(sym->global_value))));
+    });
+    return stream;
 }
 
 } // namespace lithp

--- a/src/object/types.cpp
+++ b/src/object/types.cpp
@@ -18,6 +18,7 @@ std::string type_name(Type t) {
         TYPE_NAME_CASE(SpecialForm);
         TYPE_NAME_CASE(String);
         TYPE_NAME_CASE(Symbol);
+        TYPE_NAME_CASE(Internal);
     default:
         throw std::logic_error{"unknown type " +
                                std::to_string(static_cast<int>(t))};

--- a/src/runtime/environment.cpp
+++ b/src/runtime/environment.cpp
@@ -4,7 +4,6 @@
 #include <lithp/lithp.hpp>
 
 namespace lithp::runtime {
-Environment::Environment(Environment *parent) : parent{parent} {}
 
 static void ensure_settable(Symbol *sym) {
     if (sym == nullptr) {
@@ -15,49 +14,154 @@ static void ensure_settable(Symbol *sym) {
     }
 }
 
-void Environment::set(Symbol *sym, Object *obj) {
-    ensure_settable(sym);
+namespace {
+class GlobalEnv : public Environment {
+  public:
+    virtual bool heap_allocated() override {
+        return false;
+    }
+    virtual size_t size(void) override {
+        return 0;
+    }
+    virtual Type type(void) override {
+        return Type::Internal;
+    }
+    virtual void repr(std::ostream &out) override {
+        char buffer[64] = {'\0'};
+        sprintf(buffer, "<global-env#%p>", this);
+        out << buffer;
+    }
+    virtual RefStream refs(void) override {
+        return RefStream::empty();
+    }
+    virtual Object *copy_to(void *) override {
+        throw std::logic_error{"attempting to copy global environment"};
+    }
+    virtual void set(Symbol *sym, Object *obj) override {
+        if (sym->has_global_value()) {
+            sym->set_global_value(obj);
+        } else {
+            throw std::runtime_error{
+                "attempting to change undefined variable: " + sym->get_name()};
+        }
+    }
+    virtual void def(Symbol *sym, Object *obj) override {
+        if (sym->has_global_value()) {
+            throw std::runtime_error{"redefining global variable: " +
+                                     sym->get_name()};
+        } else {
+            sym->set_global_value(obj);
+        }
+    }
+    virtual Object *get(Symbol *sym) override {
+        if (sym->has_global_value()) {
+            return sym->get_global_value();
+        } else {
+            throw std::runtime_error{"unknown variable: " + sym->get_name()};
+        }
+    }
+    virtual bool knows(Symbol *sym) override {
+        return sym->has_global_value();
+    }
+    virtual ~GlobalEnv() = default;
 
-    if (knows(sym)) {
-        definitions.insert_or_assign(sym, obj);
-    } else if (parent == nullptr) {
-        throw std::runtime_error{"cannot set unknown variable: " +
-                                 sym->get_name()};
-    } else {
+    static GlobalEnv global;
+};
+
+GlobalEnv GlobalEnv::global = GlobalEnv{};
+
+typedef struct {
+    Symbol *sym;
+    Object *val;
+} Def;
+
+class LocalEnv : public Environment {
+  public:
+    LocalEnv(Environment *parent) : parent{parent} {}
+    virtual bool heap_allocated() override {
+        return true;
+    }
+    virtual size_t size(void) override {
+        return sizeof(LocalEnv);
+    }
+    virtual Type type(void) override {
+        return Type::Internal;
+    }
+    virtual void repr(std::ostream &out) override {
+        char buffer[64] = {'\0'};
+        sprintf(buffer, "<env#%p>", this);
+        out << buffer;
+    }
+    virtual RefStream refs(void) override {
+        std::vector<Object **> ptrs;
+        for (size_t i = 0; i < ndefs; i++) {
+            ptrs.push_back(&(definitions[i].val));
+        }
+        return RefStream::concat(parent->refs(),
+                                 RefStream::of((Object **)(&parent)),
+                                 RefStream::of(ptrs));
+    }
+    virtual Object *copy_to(void *mem) override {
+        LocalEnv *copy = new (mem) LocalEnv{this->parent};
+        for (size_t i = 0; i < ndefs; i++) {
+            copy->definitions[i] = this->definitions[i];
+        }
+        return copy;
+    }
+    virtual void set(Symbol *sym, Object *obj) override {
+        ensure_settable(sym);
+
+        for (size_t i = 0; i < ndefs; i++) {
+            if (definitions[i].sym == sym) {
+                definitions[i].val = obj;
+                return;
+            }
+        }
         parent->set(sym, obj);
     }
-}
+    virtual void def(Symbol *sym, Object *obj) override {
+        ensure_settable(sym);
 
-void Environment::def(Symbol *sym, Object *obj) {
-    ensure_settable(sym);
-
-    if (knows(sym)) {
-        throw std::runtime_error{"double definition of variable: " +
-                                 sym->get_name()};
-    } else {
-        definitions[sym] = obj;
+        if (knows(sym)) {
+            throw std::runtime_error{"double definition of variable: " +
+                                     sym->get_name()};
+        } else if (ndefs == max_ndefs) {
+            throw std::runtime_error{"environment exceeded max size: " +
+                                     std::to_string(max_ndefs)};
+        } else {
+            definitions[ndefs++] = Def{.sym = sym, .val = obj};
+        }
     }
-}
-
-Object *Environment::get(Symbol *sym) {
-    auto found = definitions.find(sym);
-    if (found != definitions.end()) {
-        return found->second;
-    }
-
-    if (parent) {
+    virtual Object *get(Symbol *sym) override {
+        for (size_t i = 0; i < ndefs; i++) {
+            if (definitions[i].sym == sym) {
+                return definitions[i].val;
+            }
+        }
         return parent->get(sym);
-    } else {
-        throw std::runtime_error{"undefined variable: " + sym->get_name()};
     }
-}
+    virtual bool knows(Symbol *sym) override {
+        for (size_t i = 0; i < ndefs; i++) {
+            if (definitions[i].sym == sym) {
+                return true;
+            }
+        }
+        return false;
+    }
+    virtual ~LocalEnv() = default;
 
-bool Environment::knows(Symbol *sym) {
-    auto found = definitions.find(sym);
-    return found != definitions.end();
-}
+  private:
+    static const size_t max_ndefs = 32;
+    Environment *parent;
+    size_t ndefs = 0;
+    Def definitions[max_ndefs] = {Def{nullptr, nullptr}};
+};
+} // namespace
 
-RefStream Environment::refs() {
-    return refs_of(definitions);
+Environment *Environment::get_global() {
+    return &GlobalEnv::global;
+}
+Environment *Environment::make_local(Environment *parent) {
+    return HEAP_NEW(LocalEnv){parent};
 }
 } // namespace lithp::runtime

--- a/src/runtime/environment.cpp
+++ b/src/runtime/environment.cpp
@@ -24,7 +24,7 @@ class GlobalEnv : public Environment {
         return 0;
     }
     virtual Type type(void) override {
-        return Type::Internal;
+        return Type::Environment;
     }
     virtual void repr(std::ostream &out) override {
         char buffer[64] = {'\0'};
@@ -32,7 +32,7 @@ class GlobalEnv : public Environment {
         out << buffer;
     }
     virtual RefStream refs(void) override {
-        return RefStream::empty();
+        return Symbol::global_references();
     }
     virtual Object *copy_to(void *) override {
         throw std::logic_error{"attempting to copy global environment"};
@@ -85,7 +85,7 @@ class LocalEnv : public Environment {
         return sizeof(LocalEnv);
     }
     virtual Type type(void) override {
-        return Type::Internal;
+        return Type::Environment;
     }
     virtual void repr(std::ostream &out) override {
         char buffer[64] = {'\0'};

--- a/src/runtime/stack.cpp
+++ b/src/runtime/stack.cpp
@@ -104,11 +104,11 @@ void call_in_current_frame(Function *fun) {
     }
 }
 
-void eval_in_current_frame(SpecialForm *spec, Environment &env) {
+void eval_in_current_frame(SpecialForm *spec, Environment *env) {
     size_t nargs = num_args_in_frame();
     Object **args = begin_args_in_frame();
     try {
-        stack[current_frame()] = spec->eval(nargs, args, env);
+        stack[current_frame()] = spec->evaluate(nargs, args, env);
     } catch (const std::exception &e) {
         std::cerr << "error evaluating special form:\n";
         std::cerr << e.what() << "\n";

--- a/test/src/env_test.cpp
+++ b/test/src/env_test.cpp
@@ -2,25 +2,27 @@
 
 #include <lithp/lithp.hpp>
 
+#include "test_helper.hpp"
+
 using namespace lithp;
 
-TEST(env, lookup_here) {
-    Environment env;
+TEST_F(RuntimeTest, env_lookup_here) {
+    Environment *env = Environment::make_local(ENV);
     Symbol *sym = Symbol::intern("symbol");
     Symbol *other = Symbol::intern("another");
-    env.def(sym, Boolean::True());
+    env->def(sym, Boolean::True());
 
-    EXPECT_EQ(env.get(sym), Boolean::True());
-    EXPECT_ANY_THROW(env.get(other));
+    EXPECT_EQ(env->get(sym), Boolean::True());
+    EXPECT_ANY_THROW(env->get(other));
 }
 
-TEST(env, lookup_parent) {
-    Environment parent;
-    Environment env{&parent};
+TEST_F(RuntimeTest, env_lookup_parent) {
+    Environment *parent = Environment::make_local(ENV);
+    Environment *env = Environment::make_local(parent);
     Symbol *sym = Symbol::intern("+global-constant+");
     Symbol *other = Symbol::intern("another");
 
-    parent.def(sym, Boolean::True());
-    EXPECT_EQ(env.get(sym), Boolean::True());
-    EXPECT_ANY_THROW(env.get(other));
+    parent->def(sym, Boolean::True());
+    EXPECT_EQ(env->get(sym), Boolean::True());
+    EXPECT_ANY_THROW(env->get(other));
 }

--- a/test/src/lib_test.cpp
+++ b/test/src/lib_test.cpp
@@ -38,13 +38,14 @@ TEST_F(RuntimeTest, lib_car_cdr) {
 }
 
 TEST_F(RuntimeTest, lib_set_car_cdr) {
+    Environment *env = Environment::make_local(ENV);
     List *list = List::make(SYM("A"), SYM("B"));
     Symbol *listsym = SYM("my-list");
-    ENV.def(listsym, list);
-    ASSERT_NE(eval(listsym, ENV), nil());
-    ASSERT_EQ(eval(List::of({SYM("car"), listsym}), ENV), SYM("A"));
-    eval(List::of({SYM("set-car!"), listsym, QUOTE(SYM("C"))}), ENV);
-    EXPECT_EQ(eval(List::of({SYM("car"), listsym}), ENV), SYM("C"));
-    eval(List::of({SYM("set-cdr!"), listsym, QUOTE(SYM("D"))}), ENV);
-    EXPECT_EQ(eval(List::of({SYM("cdr"), listsym}), ENV), SYM("D"));
+    env->def(listsym, list);
+    ASSERT_NE(eval(listsym, env), nil());
+    ASSERT_EQ(eval(List::of({SYM("car"), listsym}), env), SYM("A"));
+    eval(List::of({SYM("set-car!"), listsym, QUOTE(SYM("C"))}), env);
+    EXPECT_EQ(eval(List::of({SYM("car"), listsym}), env), SYM("C"));
+    eval(List::of({SYM("set-cdr!"), listsym, QUOTE(SYM("D"))}), env);
+    EXPECT_EQ(eval(List::of({SYM("cdr"), listsym}), env), SYM("D"));
 }

--- a/test/src/sform_test.cpp
+++ b/test/src/sform_test.cpp
@@ -3,7 +3,7 @@
 using namespace lithp;
 
 bool special_form_exists(Symbol *sym) {
-    return SpecialForm::is_instance(runtime::global_env().get(sym));
+    return SpecialForm::is_instance(runtime::global_env()->get(sym));
 }
 
 TEST_F(RuntimeTest, special_forms_exist) {

--- a/test/src/test_helper.hpp
+++ b/test/src/test_helper.hpp
@@ -23,7 +23,7 @@ class RuntimeTest : public ::testing::Test {
 #define SYM Symbol::intern
 #define NUM Number::make
 #define FUN(name)                                                              \
-    Function::cast(runtime::global_env().get(Symbol::intern(name)))
+    Function::cast(runtime::global_env()->get(Symbol::intern(name)))
 #define QUOTE(form) List::of({Symbol::intern("quote"), form})
 
 lithp::Object *read_from(std::string text) {


### PR DESCRIPTION
Local environments are now fully placed on the stack. No C++ heap allocations are necessary. The  global environment is allocated indepedently by attaching values directly to the symbol table for instant lookup without additional allocations.